### PR TITLE
Mobile styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   const { openModal } = useModal();
 
   return (
-    <div className="app">
+    <div className="app" style={{ background: "red", height: "100vh" }}>
       <button type="button" onClick={() => openModal(<DemoModal />)}>
         asdas
       </button>

--- a/src/components/Background/index.tsx
+++ b/src/components/Background/index.tsx
@@ -1,11 +1,14 @@
+import useViewportSize from "../../hooks/useViewportSize";
 import * as S from "./styles";
 import { BackgroundProps } from "./types";
 
 const Background = (backgroundProps: BackgroundProps) => {
+  const { isMobile } = useViewportSize();
+
   return (
     <S.Background
       {...backgroundProps}
-      variants={S.variants}
+      variants={isMobile ? S.mobileVariants : S.variants}
       initial="closed"
       animate="open"
       exit="closed"

--- a/src/components/Background/styles.tsx
+++ b/src/components/Background/styles.tsx
@@ -9,12 +9,10 @@ export const Background = styled(motion.div)`
   position: absolute;
   top: 0;
   left: 0;
-  background: rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(5px);
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  z-index: -1;
+  z-index: 10000;
 `;
 
 export const variants = {
@@ -25,5 +23,14 @@ export const variants = {
   open: {
     backdropFilter: "blur(5px)",
     background: "rgba(255, 255, 255, 0.5)"
+  }
+};
+
+export const mobileVariants = {
+  closed: {
+    background: "rgba(0, 0, 0, 0)"
+  },
+  open: {
+    background: "rgba(0, 0, 0, 0.5)"
   }
 };

--- a/src/components/Footer/styles.tsx
+++ b/src/components/Footer/styles.tsx
@@ -6,5 +6,5 @@ export const Footer = styled.footer`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px #efefef solid;
+  border-top: 1px #efefef solid;
 `;

--- a/src/components/Footer/styles.tsx
+++ b/src/components/Footer/styles.tsx
@@ -6,5 +6,5 @@ export const Footer = styled.footer`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-top: 2px grey solid;
+  border-bottom: 1px #efefef solid;
 `;

--- a/src/components/Header/styles.tsx
+++ b/src/components/Header/styles.tsx
@@ -5,13 +5,19 @@ export const Header = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  border-bottom: 1px #efefef solid;
+
+  @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
+    justify-content: center;
+  }
 `;
 
 export const CloseButton = styled.button`
   border-radius: 25px;
-  font-size: 40px;
-  height: 50px;
-  width: 50px;
+  font-size: 32px;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,9 +25,15 @@ export const CloseButton = styled.button`
   border: none;
   color: white;
   cursor: pointer;
+  position: absolute;
+  right: 32px;
 `;
 
 export const Title = styled.h4`
   font-size: 40px;
   margin: 0;
+
+  @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
+    font-size: 20px;
+  }
 `;

--- a/src/components/Header/styles.tsx
+++ b/src/components/Header/styles.tsx
@@ -30,7 +30,7 @@ export const CloseButton = styled.button`
 `;
 
 export const Title = styled.h4`
-  font-size: 40px;
+  font-size: 24px;
   margin: 0;
 
   @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,8 +4,23 @@ import { ModalProps } from "./types";
 import Header from "../Header";
 import Body from "../Body";
 import Footer from "../Footer";
+import { useModal } from "../ModalContext";
+import { PanInfo } from "framer-motion";
+import useViewportSize from "../../hooks/useViewportSize";
 
 const Modal = (props: ModalProps) => {
+  const { closeModal } = useModal();
+  const { height } = useViewportSize();
+
+  const CLOSE_ON_DRAG_TRESHHOLD = height / 2;
+
+  const handleDragEnd = (dragInfo: PanInfo) => {
+    const { offset, velocity } = dragInfo;
+    if (offset.y > CLOSE_ON_DRAG_TRESHHOLD) {
+      closeModal();
+    }
+  };
+
   return (
     <S.Modal
       variants={S.variants}
@@ -13,6 +28,10 @@ const Modal = (props: ModalProps) => {
       initial="closed"
       animate="open"
       exit="closed"
+      drag="y"
+      dragConstraints={{ top: 5, bottom: 5 }}
+      dragElastic={{ top: 0.05, bottom: 0.1 }}
+      onDragEnd={(_, info) => handleDragEnd(info)}
     >
       <Header
         title={props.title}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -15,7 +15,7 @@ const Modal = (props: ModalProps) => {
   const CLOSE_ON_DRAG_TRESHHOLD = height / 2;
 
   const handleDragEnd = (dragInfo: PanInfo) => {
-    const { offset, velocity } = dragInfo;
+    const { offset } = dragInfo;
     if (offset.y > CLOSE_ON_DRAG_TRESHHOLD) {
       closeModal();
     }

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -11,6 +11,11 @@ export const Modal = styled(motion.section)`
   padding: 0;
   display: flex;
   flex-direction: column;
+
+  @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
+    height: 100vh;
+    margin: 32px auto 0 auto;
+  }
 `;
 
 export const variants = {

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -13,7 +13,7 @@ export const Modal = styled(motion.section)`
   flex-direction: column;
 
   @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
-    height: 100vh;
+    height: calc(100vh - 32px);
     margin: 32px auto 0 auto;
   }
 `;

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -24,7 +24,7 @@ export const variants = {
     opacity: 1
   },
   closed: {
-    y: "100%",
+    y: typeof window !== "undefined" ? window.innerHeight : 100,
     opacity: 0
   }
 };

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -15,6 +15,7 @@ export const Modal = styled(motion.section)`
   @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
     height: calc(100vh - 32px);
     margin: 32px auto 0 auto;
+    border-radius: 16px 16px 0 0;
   }
 `;
 

--- a/src/components/ModalContext/index.tsx
+++ b/src/components/ModalContext/index.tsx
@@ -1,7 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 import {
   createContext,
-  Fragment,
   ReactElement,
   useContext,
   useEffect,
@@ -11,6 +10,7 @@ import { ThemeProvider } from "styled-components";
 import Background from "../Background";
 import { modalTheme } from "../Theme";
 import { ModalContextProps, ModalProviderProps } from "./types";
+import * as S from "./styles";
 
 const ModalContext = createContext<ModalContextProps>({
   openModal: () => {},
@@ -47,7 +47,16 @@ export const ModalProvider = ({ children }: ModalProviderProps) => {
       }}
     >
       <ThemeProvider theme={modalTheme}>
-        {children}
+        <S.MainWrapper
+          variants={S.variants}
+          initial="normal"
+          animate={isOpen ? "pushed" : "normal"}
+          transition={{
+            duration: 0.3
+          }}
+        >
+          {children}
+        </S.MainWrapper>
         <AnimatePresence>
           {Modal && <Background>{Modal}</Background>}
         </AnimatePresence>

--- a/src/components/ModalContext/index.tsx
+++ b/src/components/ModalContext/index.tsx
@@ -7,7 +7,9 @@ import {
   useEffect,
   useState
 } from "react";
+import { ThemeProvider } from "styled-components";
 import Background from "../Background";
+import { modalTheme } from "../Theme";
 import { ModalContextProps, ModalProviderProps } from "./types";
 
 const ModalContext = createContext<ModalContextProps>({
@@ -44,10 +46,12 @@ export const ModalProvider = ({ children }: ModalProviderProps) => {
         closeModal
       }}
     >
-      {children}
-      <AnimatePresence>
-        {Modal && <Background>{Modal}</Background>}
-      </AnimatePresence>
+      <ThemeProvider theme={modalTheme}>
+        {children}
+        <AnimatePresence>
+          {Modal && <Background>{Modal}</Background>}
+        </AnimatePresence>
+      </ThemeProvider>
     </ModalContext.Provider>
   );
 };

--- a/src/components/ModalContext/index.tsx
+++ b/src/components/ModalContext/index.tsx
@@ -11,6 +11,7 @@ import Background from "../Background";
 import { modalTheme } from "../Theme";
 import { ModalContextProps, ModalProviderProps } from "./types";
 import * as S from "./styles";
+import useViewportSize from "../../hooks/useViewportSize";
 
 const ModalContext = createContext<ModalContextProps>({
   openModal: () => {},
@@ -25,6 +26,8 @@ export const useModal = () => {
 export const ModalProvider = ({ children }: ModalProviderProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [Modal, setModal] = useState<null | ReactElement>(null);
+
+  const { isMobile } = useViewportSize();
 
   useEffect(() => {
     setIsOpen(Boolean(Modal));
@@ -48,7 +51,7 @@ export const ModalProvider = ({ children }: ModalProviderProps) => {
     >
       <ThemeProvider theme={modalTheme}>
         <S.MainWrapper
-          variants={S.variants}
+          variants={isMobile ? S.variants : undefined}
           initial="normal"
           animate={isOpen ? "pushed" : "normal"}
           transition={{

--- a/src/components/ModalContext/styles.tsx
+++ b/src/components/ModalContext/styles.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { motion } from "framer-motion";
+
+export const MainWrapper = styled(motion.div)`
+  transform-origin: center;
+  border-radius: 16px;
+`;
+
+export const variants = {
+  normal: {
+    scale: 1
+  },
+  pushed: {
+    scale: 0.95
+  }
+};

--- a/src/components/Theme/index.ts
+++ b/src/components/Theme/index.ts
@@ -1,0 +1,14 @@
+import { DefaultTheme } from "styled-components";
+
+export const modalTheme: DefaultTheme = {
+  colors: {
+    light: "white",
+    dark: "grey"
+  },
+  breakpoints: {
+    xs: 425,
+    sm: 768,
+    md: 992,
+    lg: 1200,
+  },
+};

--- a/src/hooks/useViewportSize/index.tsx
+++ b/src/hooks/useViewportSize/index.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { modalTheme } from "../../components/Theme";
+import { DeviceSize, ViewportSizeData } from "./types";
+
+const VIEWPORT_SIZES = modalTheme.breakpoints;
+
+const useViewportSize = (): ViewportSizeData => {
+  const [deviceSize, setDeviceSize] = useState<DeviceSize>("sm");
+  const [width, setWidth] = useState(VIEWPORT_SIZES.sm);
+  const [isMobile, setIsMobile] = useState(true);
+
+  const handleResize = () => {
+    if (typeof window !== "undefined") {
+      const { innerWidth } = window;
+
+      if (innerWidth > VIEWPORT_SIZES.xs) {
+        setDeviceSize("xs");
+      }
+      if (innerWidth > VIEWPORT_SIZES.sm) {
+        setDeviceSize("xs");
+      }
+      if (innerWidth > VIEWPORT_SIZES.md) {
+        setDeviceSize("md");
+      }
+      if (innerWidth > VIEWPORT_SIZES.lg) {
+        setDeviceSize("lg");
+      }
+
+      setWidth(innerWidth);
+      setIsMobile(innerWidth < VIEWPORT_SIZES.md);
+    }
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return {
+    deviceSize,
+    width,
+    isMobile
+  };
+};
+
+export default useViewportSize;

--- a/src/hooks/useViewportSize/index.tsx
+++ b/src/hooks/useViewportSize/index.tsx
@@ -7,11 +7,12 @@ const VIEWPORT_SIZES = modalTheme.breakpoints;
 const useViewportSize = (): ViewportSizeData => {
   const [deviceSize, setDeviceSize] = useState<DeviceSize>("sm");
   const [width, setWidth] = useState(VIEWPORT_SIZES.sm);
+  const [height, setHeight] = useState(0);
   const [isMobile, setIsMobile] = useState(true);
 
   const handleResize = () => {
     if (typeof window !== "undefined") {
-      const { innerWidth } = window;
+      const { innerWidth, innerHeight } = window;
 
       if (innerWidth > VIEWPORT_SIZES.xs) {
         setDeviceSize("xs");
@@ -27,6 +28,7 @@ const useViewportSize = (): ViewportSizeData => {
       }
 
       setWidth(innerWidth);
+      setHeight(innerHeight);
       setIsMobile(innerWidth < VIEWPORT_SIZES.md);
     }
   };
@@ -41,6 +43,7 @@ const useViewportSize = (): ViewportSizeData => {
   return {
     deviceSize,
     width,
+    height,
     isMobile
   };
 };

--- a/src/hooks/useViewportSize/types.ts
+++ b/src/hooks/useViewportSize/types.ts
@@ -1,0 +1,7 @@
+export type DeviceSize = "xs" | "sm" | "md" | "lg";
+
+export interface ViewportSizeData {
+  deviceSize: DeviceSize;
+  width: number;
+  isMobile: boolean;
+};

--- a/src/hooks/useViewportSize/types.ts
+++ b/src/hooks/useViewportSize/types.ts
@@ -3,5 +3,6 @@ export type DeviceSize = "xs" | "sm" | "md" | "lg";
 export interface ViewportSizeData {
   deviceSize: DeviceSize;
   width: number;
+  height: number;
   isMobile: boolean;
 };

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -1,0 +1,18 @@
+// import original module declarations
+import "styled-components";
+
+// and extend them!
+declare module "styled-components" {
+  export interface DefaultTheme {
+    colors: {
+      light: string;
+      dark: string;
+    };
+    breakpoints: {
+      xs: number;
+      sm: number;
+      md: number;
+      lg: number;
+    };
+  }
+}


### PR DESCRIPTION
- Set some basic styles on the body so I see see the background effects taking place
- Change the effect on the background based on viewport (push back on mobile, blur on desktop)
- Add styles for different background effects based on viewport
- Adjust header styles to match iOS a bit better
- Add drag interactions to close on swipe down
- Add `useViewportSize` hook for determining if the user is on mobile or not