### PR TITLE
Animation and UX changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "framer-motion": "^4.0.3",
+    "phosphor-react": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "@types/jest": "^26.0.15",
-    "@types/node": "^12.0.0",
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
     "framer-motion": "^4.0.3",
     "phosphor-react": "^1.2.1",
     "react": "^17.0.2",
@@ -44,6 +37,13 @@
     ]
   },
   "devDependencies": {
-    "@types/styled-components": "^5.1.9"
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "@types/jest": "^26.0.15",
+    "@types/styled-components": "^5.1.9",
+    "@types/node": "^12.0.0",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,11 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>React App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
   const { openModal } = useModal();
 
   return (
-    <div className="app" style={{ background: "red", height: "100vh" }}>
+    <div className="app" style={{ background: "red", height: "100%" }}>
       <button type="button" onClick={() => openModal(<DemoModal />)}>
         Open modal
       </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
   const { openModal } = useModal();
 
   return (
-    <div className="app" style={{ background: "red", height: "100%" }}>
+    <div className="app">
       <button type="button" onClick={() => openModal(<DemoModal />)}>
         Open modal
       </button>

--- a/src/components/Background/styles.tsx
+++ b/src/components/Background/styles.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { motion } from "framer-motion";
 
 export const Background = styled(motion.div)`
-  height: 100vh;
+  height: 100%;
   width: 100vw;
   margin: 0;
   padding: 0;
@@ -13,6 +13,7 @@ export const Background = styled(motion.div)`
   justify-content: center;
   align-items: flex-start;
   z-index: 10000;
+  overflow: hidden;
 `;
 
 export const variants = {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import { useModal } from "../ModalContext";
 import * as S from "./styles";
 import { HeaderProps } from "./types";
+import { X } from "phosphor-react";
 
 const Header = (props: HeaderProps) => {
   const { closeModal } = useModal();
@@ -21,7 +22,7 @@ const Header = (props: HeaderProps) => {
         onClick={(event) => handleClose(event)}
         aria-label="Close modal"
       >
-        &times;
+        <X size={24} weight="bold" />
       </S.CloseButton>
     </S.Header>
   );

--- a/src/components/Header/styles.tsx
+++ b/src/components/Header/styles.tsx
@@ -22,8 +22,10 @@ export const CloseButton = styled.button`
   align-items: center;
   justify-content: center;
   margin: 0;
+  padding: 0;
   border: none;
   color: white;
+  background: #efefef;
   cursor: pointer;
   position: absolute;
   right: 32px;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -22,7 +22,7 @@ const Modal = (props: ModalProps) => {
   useScrollFreeze();
   useClickOutside(ModalRef, () => props.clickOutsideToClose && closeModal());
 
-  const CLOSE_ON_DRAG_TRESHHOLD = height / 2;
+  const CLOSE_ON_DRAG_TRESHHOLD = height / 8;
 
   const handleDragEnd = (dragInfo: PanInfo) => {
     const { offset } = dragInfo;
@@ -43,8 +43,8 @@ const Modal = (props: ModalProps) => {
       animate="open"
       exit="closed"
       drag="y"
-      dragConstraints={{ top: 5, bottom: 5 }}
-      dragElastic={{ top: 0.05, bottom: 0.1 }}
+      dragConstraints={{ top: 5, bottom: height / 3 }}
+      dragElastic={{ top: 0.05, bottom: 0.5 }}
       onDragEnd={(_, info) => handleDragEnd(info)}
       ref={ModalRef}
       aria-labelledby={`${props.id}_header`}

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -5,6 +5,7 @@ export const Modal = styled(motion.section)`
   width: 720px;
   min-height: 75vh;
   /* height: calc(100% - 32px); */
+  height: 100%;
   background: white;
   box-shadow: 0 0 10px 10px rgba(0, 0, 0, 0.1);
   margin: 12.5vh auto 0 auto;
@@ -16,6 +17,7 @@ export const Modal = styled(motion.section)`
 
   @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
     height: calc(100% - 32px);
+    height: 100%;
     margin: 32px auto 0 auto;
     border-radius: 16px 16px 0 0;
   }
@@ -32,7 +34,7 @@ export const variants = {
     opacity: 1
   },
   closed: {
-    y: typeof window !== "undefined" ? window.innerHeight : 100,
+    y: 400,
     opacity: 0
   }
 };

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -4,8 +4,6 @@ import { motion } from "framer-motion";
 export const Modal = styled(motion.section)`
   width: 720px;
   min-height: 75vh;
-  /* height: calc(100% - 32px); */
-  height: 100%;
   background: white;
   box-shadow: 0 0 10px 10px rgba(0, 0, 0, 0.1);
   margin: 12.5vh auto 0 auto;

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 export const Modal = styled(motion.section)`
   width: 720px;
   min-height: 75vh;
+  /* height: calc(100% - 32px); */
   background: white;
   box-shadow: 0 0 10px 10px rgba(0, 0, 0, 0.1);
   margin: 12.5vh auto 0 auto;
@@ -11,9 +12,10 @@ export const Modal = styled(motion.section)`
   padding: 0;
   display: flex;
   flex-direction: column;
+  max-width: 100%;
 
   @media (max-width: ${(props) => props.theme.breakpoints.sm}px) {
-    height: calc(100vh - 32px);
+    height: calc(100% - 32px);
     margin: 32px auto 0 auto;
     border-radius: 16px 16px 0 0;
   }

--- a/src/components/Modal/styles.tsx
+++ b/src/components/Modal/styles.tsx
@@ -40,7 +40,7 @@ export const variants = {
 };
 
 export const transition = {
-  damping: 20,
+  damping: 22,
   restDelta: 0.001,
   stiffness: 180,
   type: "spring"

--- a/src/components/ModalContext/styles.tsx
+++ b/src/components/ModalContext/styles.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 export const MainWrapper = styled(motion.div)`
   transform-origin: center;
   border-radius: 16px;
+  height: 100%;
 `;
 
 export const variants = {

--- a/src/hooks/useScrollFreeze/index.ts
+++ b/src/hooks/useScrollFreeze/index.ts
@@ -4,7 +4,7 @@ const useScrollFreeze = (target: HTMLElement = document.body): void => {
 
   const freeze = (target: HTMLElement) => {
     target.style.overflow = "hidden";
-    target.style.height = "100vh";
+    target.style.height = "100%";
   };
 
   const unfreeze = (target: HTMLElement) => {

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+html, body, #root {
+  height: 100%;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,16 +5,15 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-image: url("./logo.svg");
-  background-repeat: no-repeat;
-  background-size: cover;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-}
-
-html, body, #root {
+html, body, #root, .app {
   height: 100%;
+}
+
+.app {
+  background: red;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8082,6 +8082,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+phosphor-react@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/phosphor-react/-/phosphor-react-1.2.1.tgz#f897bef4ef022bd7162bccca3a9dd584e65d36f0"
+  integrity sha512-1AviNwceMegZWdV1Xuq5f73eiI99cKCCrjRPM1Ov49byeJQue4Nu4CzvEafIKa+mexQYWaYes3dGFUp9s0mFnw==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"


### PR DESCRIPTION
- Reorganise package json so keep dependencies in check
- Use phosphor icons instead of unicode characters for consistent sizing and experience across devices
- Reduce `index.html` comments 
- set demo app styles in CSS
- Prevent minor jank on iOS with the background unmounting
- use `100%` instead of `100vh` since mobile browsers adjust their viewport size as scroll
- Reduce swipe down to dismiss threshold to match iOS behaviour